### PR TITLE
Fix comment for smartcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ nmap s <Plug>(easymotion-s)
 " Need one more keystroke, but on average, it may be more comfortable.
 nmap s <Plug>(easymotion-s2)
 
-" Turn on case sensitive feature
+" Turn on case insensitive feature
 let g:EasyMotion_smartcase = 1
 
 " JK motions: Line motions


### PR DESCRIPTION
It is definitely not case sensitive.

However, I don't know whether it should be labeled as 'case insensitive' or just 'smartcase'.

What's your opinion?