### PR TITLE
Use mapping helper function for almost all mappings

### DIFF
--- a/plugin/EasyMotion.vim
+++ b/plugin/EasyMotion.vim
@@ -173,11 +173,11 @@ call s:motion_map_helper({
 
 " -- Search Motion {{{
 call s:motion_map_helper({
-    \ 'n'               : {'fnc' : 'Search', 'direction': 0, 'respectdirection': 0},
-    \ 'N'               : {'fnc' : 'Search', 'direction': 1, 'respectdirection': 0},
-    \ 'bd-n'            : {'fnc' : 'Search', 'direction': 2, 'respectdirection': 0},
-    \ 'vim-n'           : {'fnc' : 'Search', 'direction': 0, 'respectdirection': 1},
-    \ 'vim-N'           : {'fnc' : 'Search', 'direction': 1, 'respectdirection': 1},
+    \ 'n'               : {'fnc' : 'Search', 'direction': 0, 'respect_direction': 0},
+    \ 'N'               : {'fnc' : 'Search', 'direction': 1, 'respect_direction': 0},
+    \ 'bd-n'            : {'fnc' : 'Search', 'direction': 2, 'respect_direction': 0},
+    \ 'vim-n'           : {'fnc' : 'Search', 'direction': 0, 'respect_direction': 1},
+    \ 'vim-N'           : {'fnc' : 'Search', 'direction': 1, 'respect_direction': 1},
     \ })
 "}}}
 

--- a/plugin/EasyMotion.vim
+++ b/plugin/EasyMotion.vim
@@ -64,10 +64,13 @@ function! s:motion_map_helper(motions) "{{{
         let l:mapargs = []
         let l:xmapargs = []
         if dict.fnc ==# 'S' || dict.fnc ==# 'SL' || dict.fnc ==# 'T' || dict.fnc ==# 'TL'
-            let l:mapargs += [dict.cnt, 0, dict.direction]
+            let l:mapargs  += [dict.cnt, 0, dict.direction]
             let l:xmapargs += [dict.cnt, 1, dict.direction]
+        elseif dict.fnc ==# 'Search'
+            let l:mapargs  += [0, dict.direction, dict.respect_direction]
+            let l:xmapargs += [1, dict.direction, dict.respect_direction]
         else
-            let l:mapargs += [0, dict.direction]
+            let l:mapargs  += [0, dict.direction]
             let l:xmapargs += [1, dict.direction]
         endif
 

--- a/plugin/EasyMotion.vim
+++ b/plugin/EasyMotion.vim
@@ -61,17 +61,17 @@ let g:EasyMotion_disable_two_key_combo     =
 
 function! s:motion_map_helper(motions) "{{{
     for [name, dict] in items(a:motions)
-        let l:mapargs = []
-        let l:xmapargs = []
+        let mapargs = []
+        let xmapargs = []
         if dict.fnc ==# 'S' || dict.fnc ==# 'SL' || dict.fnc ==# 'T' || dict.fnc ==# 'TL'
-            let l:mapargs  += [dict.cnt, 0, dict.direction]
-            let l:xmapargs += [dict.cnt, 1, dict.direction]
+            let mapargs  += [dict.cnt, 0, dict.direction]
+            let xmapargs += [dict.cnt, 1, dict.direction]
         elseif dict.fnc ==# 'Search'
-            let l:mapargs  += [0, dict.direction, dict.respect_direction]
-            let l:xmapargs += [1, dict.direction, dict.respect_direction]
+            let mapargs  += [0, dict.direction, dict.respect_direction]
+            let xmapargs += [1, dict.direction, dict.respect_direction]
         else
-            let l:mapargs  += [0, dict.direction]
-            let l:xmapargs += [1, dict.direction]
+            let mapargs  += [0, dict.direction]
+            let xmapargs += [1, dict.direction]
         endif
 
         silent exec 'noremap  <silent><Plug>(easymotion-'.name.')' .

--- a/plugin/EasyMotion.vim
+++ b/plugin/EasyMotion.vim
@@ -184,13 +184,6 @@ call s:motion_map_helper({
     \ })
 "}}}
 
-" -- Next, Previous Motion {{{
-call s:motion_map_helper({
-    \ 'next'            : {'fnc' : 'NextPrevious', 'direction': 0},
-    \ 'previous'        : {'fnc' : 'NextPrevious', 'direction': 1},
-    \ })
-"}}}
-
 " -- Line Motion {{{
 call s:motion_map_helper({
     \ 'wl'              : {'fnc' : 'WBL', 'direction': 0},
@@ -203,6 +196,18 @@ call s:motion_map_helper({
     \ 'linebackward'    : {'fnc' : 'WBL', 'direction': 1},
     \ 'lineanywhere'    : {'fnc' : 'WBL', 'direction': 2},
     \ })
+"}}}
+
+" -- Next, Previous Motion {{{
+noremap  <silent><Plug>(easymotion-next)
+    \      :<C-u>call EasyMotion#NextPrevious(0,0)<CR>
+xnoremap <silent><Plug>(easymotion-next)
+    \      :<C-u>call EasyMotion#NextPrevious(1,0)<CR>
+
+noremap  <silent><Plug>(easymotion-prev)
+    \      :<C-u>call EasyMotion#NextPrevious(0,1)<CR>
+xnoremap <silent><Plug>(easymotion-prev)
+    \      :<C-u>call EasyMotion#NextPrevious(1,1)<CR>
 "}}}
 
 " -- Repeat Motion {{{

--- a/plugin/EasyMotion.vim
+++ b/plugin/EasyMotion.vim
@@ -195,9 +195,9 @@ call s:motion_map_helper({
     \ 'el'              : {'fnc' : 'EL' , 'direction': 0},
     \ 'gel'             : {'fnc' : 'EL' , 'direction': 1},
     \ 'bd-el'           : {'fnc' : 'EL' , 'direction': 2},
-    \ 'lineforward'     : {'fnc' : 'WBL', 'direction': 0},
-    \ 'linebackward'    : {'fnc' : 'WBL', 'direction': 1},
-    \ 'lineanywhere'    : {'fnc' : 'WBL', 'direction': 2},
+    \ 'lineforward'     : {'fnc' : 'LineAnywhere', 'direction': 0},
+    \ 'linebackward'    : {'fnc' : 'LineAnywhere', 'direction': 1},
+    \ 'lineanywhere'    : {'fnc' : 'LineAnywhere', 'direction': 2},
     \ })
 "}}}
 

--- a/plugin/EasyMotion.vim
+++ b/plugin/EasyMotion.vim
@@ -59,170 +59,150 @@ let g:EasyMotion_disable_two_key_combo     =
 " Note: bd is short for bidirectional
 "       l is short for (within) line
 
-function! s:find_motion_map_helper(motions) "{{{
+function! s:motion_map_helper(motions) "{{{
     for [name, dict] in items(a:motions)
+        let l:mapargs = []
+        let l:xmapargs = []
+        if dict.fnc ==# 'S' || dict.fnc ==# 'SL' || dict.fnc ==# 'T' || dict.fnc ==# 'TL'
+            let l:mapargs += [dict.cnt, 0, dict.direction]
+            let l:xmapargs += [dict.cnt, 1, dict.direction]
+        else
+            let l:mapargs += [0, dict.direction]
+            let l:xmapargs += [1, dict.direction]
+        endif
+
         silent exec 'noremap  <silent><Plug>(easymotion-'.name.')' .
-            \ '      :<C-u>call EasyMotion#'. dict.fnc .'('. dict.cnt .',0,'. dict.direction .')<CR>'
+            \ '      :<C-u>call EasyMotion#' . dict.fnc . '('. join(mapargs, ',') . ')<CR>'
         silent exec 'xnoremap <silent><Plug>(easymotion-'.name.')' .
-            \ ' <Esc>:<C-u>call EasyMotion#'. dict.fnc .'('. dict.cnt .',1,'. dict.direction .')<CR>'
+            \ ' <Esc>:<C-u>call EasyMotion#' . dict.fnc . '('. join(xmapargs, ',') . ')<CR>'
     " Example:
     " noremap  <silent><Plug>(easymotion-f2) :<C-u>call EasyMotion#S(2,1,0)<CR>
     " xnoremap <silent><Plug>(easymotion-f2) <Esc>:<C-u>call EasyMotion#S(2,1,0)<CR>
     endfor
 endfunction "}}}
+
 " Find Motion: {{{
-call s:find_motion_map_helper({
-    \ 'f'      : {'fnc' : 'S' , 'cnt' : 1, 'direction'  : 0},
-    \ 'F'      : {'fnc' : 'S' , 'cnt' : 1, 'direction'  : 1},
-    \ 's'      : {'fnc' : 'S' , 'cnt' : 1, 'direction'  : 2},
-    \ 'bd-f'   : {'fnc' : 'S' , 'cnt' : 1, 'direction'  : 2},
-    \ 't'      : {'fnc' : 'T' , 'cnt' : 1, 'direction'  : 0},
-    \ 'T'      : {'fnc' : 'T' , 'cnt' : 1, 'direction'  : 1},
-    \ 'bd-t'   : {'fnc' : 'T' , 'cnt' : 1, 'direction'  : 2},
-    \ 'fl'     : {'fnc' : 'SL', 'cnt' : 1, 'direction'  : 0},
-    \ 'Fl'     : {'fnc' : 'SL', 'cnt' : 1, 'direction'  : 1},
-    \ 'sl'     : {'fnc' : 'SL', 'cnt' : 1, 'direction'  : 2},
-    \ 'bd-fl'  : {'fnc' : 'SL', 'cnt' : 1, 'direction'  : 2},
-    \ 'tl'     : {'fnc' : 'TL', 'cnt' : 1, 'direction'  : 0},
-    \ 'Tl'     : {'fnc' : 'TL', 'cnt' : 1, 'direction'  : 1},
-    \ 'bd-tl'  : {'fnc' : 'TL', 'cnt' : 1, 'direction'  : 2},
+call s:motion_map_helper({
+    \ 'f'               : {'fnc' : 'S'  , 'cnt' : 1, 'direction'  : 0},
+    \ 'F'               : {'fnc' : 'S'  , 'cnt' : 1, 'direction'  : 1},
+    \ 's'               : {'fnc' : 'S'  , 'cnt' : 1, 'direction'  : 2},
+    \ 'bd-f'            : {'fnc' : 'S'  , 'cnt' : 1, 'direction'  : 2},
+    \ 't'               : {'fnc' : 'T'  , 'cnt' : 1, 'direction'  : 0},
+    \ 'T'               : {'fnc' : 'T'  , 'cnt' : 1, 'direction'  : 1},
+    \ 'bd-t'            : {'fnc' : 'T'  , 'cnt' : 1, 'direction'  : 2},
+    \ 'fl'              : {'fnc' : 'SL' , 'cnt' : 1, 'direction'  : 0},
+    \ 'Fl'              : {'fnc' : 'SL' , 'cnt' : 1, 'direction'  : 1},
+    \ 'sl'              : {'fnc' : 'SL' , 'cnt' : 1, 'direction'  : 2},
+    \ 'bd-fl'           : {'fnc' : 'SL' , 'cnt' : 1, 'direction'  : 2},
+    \ 'tl'              : {'fnc' : 'TL' , 'cnt' : 1, 'direction'  : 0},
+    \ 'Tl'              : {'fnc' : 'TL' , 'cnt' : 1, 'direction'  : 1},
+    \ 'bd-tl'           : {'fnc' : 'TL' , 'cnt' : 1, 'direction'  : 2},
     \
-    \ 'f2'     : {'fnc' : 'S' , 'cnt' : 2, 'direction'  : 0},
-    \ 'F2'     : {'fnc' : 'S' , 'cnt' : 2, 'direction'  : 1},
-    \ 's2'     : {'fnc' : 'S' , 'cnt' : 2, 'direction'  : 2},
-    \ 'bd-f2'  : {'fnc' : 'S' , 'cnt' : 2, 'direction'  : 2},
-    \ 't2'     : {'fnc' : 'T' , 'cnt' : 2, 'direction'  : 0},
-    \ 'T2'     : {'fnc' : 'T' , 'cnt' : 2, 'direction'  : 1},
-    \ 'bd-t2'  : {'fnc' : 'T' , 'cnt' : 2, 'direction'  : 2},
-    \ 'fl2'    : {'fnc' : 'SL', 'cnt' : 2, 'direction'  : 0},
-    \ 'Fl2'    : {'fnc' : 'SL', 'cnt' : 2, 'direction'  : 1},
-    \ 'sl2'    : {'fnc' : 'SL', 'cnt' : 2, 'direction'  : 2},
-    \ 'bd-fl2' : {'fnc' : 'SL', 'cnt' : 2, 'direction'  : 2},
-    \ 'tl2'    : {'fnc' : 'TL', 'cnt' : 2, 'direction'  : 0},
-    \ 'Tl2'    : {'fnc' : 'TL', 'cnt' : 2, 'direction'  : 1},
-    \ 'bd-tl2' : {'fnc' : 'TL', 'cnt' : 2, 'direction'  : 2},
+    \ 'f2'              : {'fnc' : 'S'  , 'cnt' : 2, 'direction'  : 0},
+    \ 'F2'              : {'fnc' : 'S'  , 'cnt' : 2, 'direction'  : 1},
+    \ 's2'              : {'fnc' : 'S'  , 'cnt' : 2, 'direction'  : 2},
+    \ 'bd-f2'           : {'fnc' : 'S'  , 'cnt' : 2, 'direction'  : 2},
+    \ 't2'              : {'fnc' : 'T'  , 'cnt' : 2, 'direction'  : 0},
+    \ 'T2'              : {'fnc' : 'T'  , 'cnt' : 2, 'direction'  : 1},
+    \ 'bd-t2'           : {'fnc' : 'T'  , 'cnt' : 2, 'direction'  : 2},
+    \ 'fl2'             : {'fnc' : 'SL' , 'cnt' : 2, 'direction'  : 0},
+    \ 'Fl2'             : {'fnc' : 'SL' , 'cnt' : 2, 'direction'  : 1},
+    \ 'sl2'             : {'fnc' : 'SL' , 'cnt' : 2, 'direction'  : 2},
+    \ 'bd-fl2'          : {'fnc' : 'SL' , 'cnt' : 2, 'direction'  : 2},
+    \ 'tl2'             : {'fnc' : 'TL' , 'cnt' : 2, 'direction'  : 0},
+    \ 'Tl2'             : {'fnc' : 'TL' , 'cnt' : 2, 'direction'  : 1},
+    \ 'bd-tl2'          : {'fnc' : 'TL' , 'cnt' : 2, 'direction'  : 2},
     \
-    \ 'fn'     : {'fnc' : 'S' , 'cnt' : -1, 'direction' : 0},
-    \ 'Fn'     : {'fnc' : 'S' , 'cnt' : -1, 'direction' : 1},
-    \ 'sn'     : {'fnc' : 'S' , 'cnt' : -1, 'direction' : 2},
-    \ 'bd-fn'  : {'fnc' : 'S' , 'cnt' : -1, 'direction' : 2},
-    \ 'tn'     : {'fnc' : 'T' , 'cnt' : -1, 'direction' : 0},
-    \ 'Tn'     : {'fnc' : 'T' , 'cnt' : -1, 'direction' : 1},
-    \ 'bd-tn'  : {'fnc' : 'T' , 'cnt' : -1, 'direction' : 2},
-    \ 'fln'    : {'fnc' : 'SL', 'cnt' : -1, 'direction' : 0},
-    \ 'Fln'    : {'fnc' : 'SL', 'cnt' : -1, 'direction' : 1},
-    \ 'sln'    : {'fnc' : 'SL', 'cnt' : -1, 'direction' : 2},
-    \ 'bd-fln' : {'fnc' : 'SL', 'cnt' : -1, 'direction' : 2},
-    \ 'tln'    : {'fnc' : 'TL', 'cnt' : -1, 'direction' : 0},
-    \ 'Tln'    : {'fnc' : 'TL', 'cnt' : -1, 'direction' : 1},
-    \ 'bd-tln' : {'fnc' : 'TL', 'cnt' : -1, 'direction' : 2},
-    \ })
+    \ 'fn'              : {'fnc' : 'S'  , 'cnt' : -1, 'direction' : 0},
+    \ 'Fn'              : {'fnc' : 'S'  , 'cnt' : -1, 'direction' : 1},
+    \ 'sn'              : {'fnc' : 'S'  , 'cnt' : -1, 'direction' : 2},
+    \ 'bd-fn'           : {'fnc' : 'S'  , 'cnt' : -1, 'direction' : 2},
+    \ 'tn'              : {'fnc' : 'T'  , 'cnt' : -1, 'direction' : 0},
+    \ 'Tn'              : {'fnc' : 'T'  , 'cnt' : -1, 'direction' : 1},
+    \ 'bd-tn'           : {'fnc' : 'T'  , 'cnt' : -1, 'direction' : 2},
+    \ 'fln'             : {'fnc' : 'SL' , 'cnt' : -1, 'direction' : 0},
+    \ 'Fln'             : {'fnc' : 'SL' , 'cnt' : -1, 'direction' : 1},
+    \ 'sln'             : {'fnc' : 'SL' , 'cnt' : -1, 'direction' : 2},
+    \ 'bd-fln'          : {'fnc' : 'SL' , 'cnt' : -1, 'direction' : 2},
+    \ 'tln'             : {'fnc' : 'TL' , 'cnt' : -1, 'direction' : 0},
+    \ 'Tln'             : {'fnc' : 'TL' , 'cnt' : -1, 'direction' : 1},
+    \ 'bd-tln'          : {'fnc' : 'TL' , 'cnt' : -1, 'direction' : 2},
+    \ }) 
 "}}}
 
 " -- Word Motion {{{
-" Word: {{{
-noremap  <silent><Plug>(easymotion-w)          :<C-u>call EasyMotion#WB(0,0)<CR>
-xnoremap <silent><Plug>(easymotion-w)     <Esc>:<C-u>call EasyMotion#WB(1,0)<CR>
-noremap  <silent><Plug>(easymotion-b)          :<C-u>call EasyMotion#WB(0,1)<CR>
-xnoremap <silent><Plug>(easymotion-b)     <Esc>:<C-u>call EasyMotion#WB(1,1)<CR>
-noremap  <silent><Plug>(easymotion-bd-w)       :<C-u>call EasyMotion#WB(0,2)<CR>
-xnoremap <silent><Plug>(easymotion-bd-w)  <Esc>:<C-u>call EasyMotion#WB(1,2)<CR>
-"}}}
-
-" WORD: {{{
-noremap  <silent><Plug>(easymotion-W)         :<C-u>call EasyMotion#WBW(0,0)<CR>
-xnoremap <silent><Plug>(easymotion-W)    <Esc>:<C-u>call EasyMotion#WBW(1,0)<CR>
-noremap  <silent><Plug>(easymotion-B)         :<C-u>call EasyMotion#WBW(0,1)<CR>
-xnoremap <silent><Plug>(easymotion-B)    <Esc>:<C-u>call EasyMotion#WBW(1,1)<CR>
-noremap  <silent><Plug>(easymotion-bd-W)      :<C-u>call EasyMotion#WBW(0,2)<CR>
-xnoremap <silent><Plug>(easymotion-bd-W) <Esc>:<C-u>call EasyMotion#WBW(1,2)<CR>
-"}}}
-
-" iskeyword {{{
-noremap  <silent><Plug>(easymotion-iskeyword-w)         :<C-u>call EasyMotion#WBK(0,0)<CR>
-xnoremap <silent><Plug>(easymotion-iskeyword-w)    <Esc>:<C-u>call EasyMotion#WBK(1,0)<CR>
-noremap  <silent><Plug>(easymotion-iskeyword-b)         :<C-u>call EasyMotion#WBK(0,1)<CR>
-xnoremap <silent><Plug>(easymotion-iskeyword-b)    <Esc>:<C-u>call EasyMotion#WBK(1,1)<CR>
-noremap  <silent><Plug>(easymotion-iskeyword-bd-w)      :<C-u>call EasyMotion#WBK(0,2)<CR>
-xnoremap <silent><Plug>(easymotion-iskeyword-bd-w) <Esc>:<C-u>call EasyMotion#WBK(1,2)<CR>
-" }}}
-
-" End Word: {{{
-noremap  <silent><Plug>(easymotion-e)         :<C-u>call EasyMotion#E(0,0)<CR>
-xnoremap <silent><Plug>(easymotion-e)    <Esc>:<C-u>call EasyMotion#E(1,0)<CR>
-noremap  <silent><Plug>(easymotion-ge)        :<C-u>call EasyMotion#E(0,1)<CR>
-xnoremap <silent><Plug>(easymotion-ge)   <Esc>:<C-u>call EasyMotion#E(1,1)<CR>
-noremap  <silent><Plug>(easymotion-bd-e)      :<C-u>call EasyMotion#E(0,2)<CR>
-xnoremap <silent><Plug>(easymotion-bd-e) <Esc>:<C-u>call EasyMotion#E(1,2)<CR>
-"}}}
-
-" END WORD: {{{
-noremap  <silent><Plug>(easymotion-E)         :<C-u>call EasyMotion#EW(0,0)<CR>
-xnoremap <silent><Plug>(easymotion-E)    <Esc>:<C-u>call EasyMotion#EW(1,0)<CR>
-noremap  <silent><Plug>(easymotion-gE)        :<C-u>call EasyMotion#EW(0,1)<CR>
-xnoremap <silent><Plug>(easymotion-gE)   <Esc>:<C-u>call EasyMotion#EW(1,1)<CR>
-noremap  <silent><Plug>(easymotion-bd-E)      :<C-u>call EasyMotion#EW(0,2)<CR>
-xnoremap <silent><Plug>(easymotion-bd-E) <Esc>:<C-u>call EasyMotion#EW(1,2)<CR>
-"}}}
-
-" iskeyword End: {{{
-noremap  <silent><Plug>(easymotion-iskeyword-e)         :<C-u>call EasyMotion#EK(0,0)<CR>
-xnoremap <silent><Plug>(easymotion-iskeyword-e)    <Esc>:<C-u>call EasyMotion#EK(1,0)<CR>
-noremap  <silent><Plug>(easymotion-iskeyword-ge)        :<C-u>call EasyMotion#EK(0,1)<CR>
-xnoremap <silent><Plug>(easymotion-iskeyword-ge)   <Esc>:<C-u>call EasyMotion#EK(1,1)<CR>
-noremap  <silent><Plug>(easymotion-iskeyword-bd-e)      :<C-u>call EasyMotion#EK(0,2)<CR>
-xnoremap <silent><Plug>(easymotion-iskeyword-bd-e) <Esc>:<C-u>call EasyMotion#EK(1,2)<CR>
-"}}}
+call s:motion_map_helper({
+    \ 'w'               : {'fnc' : 'WB' , 'direction' : 0},
+    \ 'b'               : {'fnc' : 'WB' , 'direction' : 1},
+    \ 'bd-w'            : {'fnc' : 'WB' , 'direction' : 2},
+    \ 'W'               : {'fnc' : 'WBW', 'direction' : 0},
+    \ 'B'               : {'fnc' : 'WBW', 'direction' : 1},
+    \ 'bd-W'            : {'fnc' : 'WBW', 'direction' : 2},
+    \ 'iskeyword-w'     : {'fnc' : 'WBK', 'direction' : 0},
+    \ 'iskeyword-b'     : {'fnc' : 'WBK', 'direction' : 1},
+    \ 'iskeyword-bd-w'  : {'fnc' : 'WBK', 'direction' : 2},
+    \
+    \ 'e'               : {'fnc' : 'E'  , 'direction' : 0},
+    \ 'ge'              : {'fnc' : 'E'  , 'direction' : 1},
+    \ 'bd-e'            : {'fnc' : 'E'  , 'direction' : 2},
+    \ 'E'               : {'fnc' : 'EW' , 'direction' : 0},
+    \ 'gE'              : {'fnc' : 'EW' , 'direction' : 1},
+    \ 'bd-E'            : {'fnc' : 'EW' , 'direction' : 2},
+    \ 'iskeyword-e'     : {'fnc' : 'EK' , 'direction' : 0},
+    \ 'iskeyword-ge'    : {'fnc' : 'EK' , 'direction' : 1},
+    \ 'iskeyword-bd-e'  : {'fnc' : 'EK' , 'direction' : 2},
+    \ })
 "}}}
 
 " -- JK Motion {{{
-noremap  <silent><Plug>(easymotion-j)          :<C-u>call EasyMotion#JK(0,0)<CR>
-xnoremap <silent><Plug>(easymotion-j)     <Esc>:<C-u>call EasyMotion#JK(1,0)<CR>
-noremap  <silent><Plug>(easymotion-k)          :<C-u>call EasyMotion#JK(0,1)<CR>
-xnoremap <silent><Plug>(easymotion-k)     <Esc>:<C-u>call EasyMotion#JK(1,1)<CR>
-noremap  <silent><Plug>(easymotion-bd-jk)      :<C-u>call EasyMotion#JK(0,2)<CR>
-xnoremap <silent><Plug>(easymotion-bd-jk) <Esc>:<C-u>call EasyMotion#JK(1,2)<CR>
-
-" Start of Line JK {{{
-noremap  <silent><Plug>(easymotion-sol-j)          :<C-u>call EasyMotion#Sol(0,0)<CR>
-xnoremap <silent><Plug>(easymotion-sol-j)     <Esc>:<C-u>call EasyMotion#Sol(1,0)<CR>
-noremap  <silent><Plug>(easymotion-sol-k)          :<C-u>call EasyMotion#Sol(0,1)<CR>
-xnoremap <silent><Plug>(easymotion-sol-k)     <Esc>:<C-u>call EasyMotion#Sol(1,1)<CR>
-noremap  <silent><Plug>(easymotion-sol-bd-jk)      :<C-u>call EasyMotion#Sol(0,2)<CR>
-xnoremap <silent><Plug>(easymotion-sol-bd-jk) <Esc>:<C-u>call EasyMotion#Sol(1,2)<CR>
-"}}}
-
-" End of Line JK {{{
-noremap  <silent><Plug>(easymotion-eol-j)          :<C-u>call EasyMotion#Eol(0,0)<CR>
-xnoremap <silent><Plug>(easymotion-eol-j)     <Esc>:<C-u>call EasyMotion#Eol(1,0)<CR>
-noremap  <silent><Plug>(easymotion-eol-k)          :<C-u>call EasyMotion#Eol(0,1)<CR>
-xnoremap <silent><Plug>(easymotion-eol-k)     <Esc>:<C-u>call EasyMotion#Eol(1,1)<CR>
-noremap  <silent><Plug>(easymotion-eol-bd-jk)      :<C-u>call EasyMotion#Eol(0,2)<CR>
-xnoremap <silent><Plug>(easymotion-eol-bd-jk) <Esc>:<C-u>call EasyMotion#Eol(1,2)<CR>
-"}}}
-
+call s:motion_map_helper({
+    \ 'j'               : {'fnc' : 'JK' , 'direction' : 0},
+    \ 'k'               : {'fnc' : 'JK' , 'direction' : 1},
+    \ 'bd-jk'           : {'fnc' : 'JK' , 'direction' : 2},
+    \ 'sol-j'           : {'fnc' : 'Sol', 'direction' : 0},
+    \ 'sol-k'           : {'fnc' : 'Sol', 'direction' : 1},
+    \ 'sol-bd-jk'       : {'fnc' : 'Sol', 'direction' : 2},
+    \ 'eol-j'           : {'fnc' : 'Eol', 'direction' : 0},
+    \ 'eol-k'           : {'fnc' : 'Eol', 'direction' : 1},
+    \ 'eol-bd-jk'       : {'fnc' : 'Eol', 'direction' : 2},
+    \ })
 "}}}
 
 " -- Search Motion {{{
-noremap  <silent><Plug>(easymotion-n)         :<C-u>call EasyMotion#Search(0,0,0)<CR>
-xnoremap <silent><Plug>(easymotion-n)    <Esc>:<C-u>call EasyMotion#Search(1,0,0)<CR>
-noremap  <silent><Plug>(easymotion-N)         :<C-u>call EasyMotion#Search(0,1,0)<CR>
-xnoremap <silent><Plug>(easymotion-N)    <Esc>:<C-u>call EasyMotion#Search(1,1,0)<CR>
-
-noremap  <silent><Plug>(easymotion-vim-n)      :<C-u>call EasyMotion#Search(0,0,1)<CR>
-xnoremap <silent><Plug>(easymotion-vim-n) <Esc>:<C-u>call EasyMotion#Search(1,0,1)<CR>
-noremap  <silent><Plug>(easymotion-vim-N)      :<C-u>call EasyMotion#Search(0,1,1)<CR>
-xnoremap <silent><Plug>(easymotion-vim-N) <Esc>:<C-u>call EasyMotion#Search(1,1,1)<CR>
-
-noremap  <silent><Plug>(easymotion-bd-n)      :<C-u>call EasyMotion#Search(0,2,0)<CR>
-xnoremap <silent><Plug>(easymotion-bd-n) <Esc>:<C-u>call EasyMotion#Search(1,2,0)<CR>
+call s:motion_map_helper({
+    \ 'n'               : {'fnc' : 'Search', 'direction': 0, 'respectdirection': 0},
+    \ 'N'               : {'fnc' : 'Search', 'direction': 1, 'respectdirection': 0},
+    \ 'bd-n'            : {'fnc' : 'Search', 'direction': 2, 'respectdirection': 0},
+    \ 'vim-n'           : {'fnc' : 'Search', 'direction': 0, 'respectdirection': 1},
+    \ 'vim-N'           : {'fnc' : 'Search', 'direction': 1, 'respectdirection': 1},
+    \ })
 "}}}
 
 " -- Jump To Anywhere Motion {{{
-noremap  <silent><Plug>(easymotion-jumptoanywhere)
-    \      :<C-u>call EasyMotion#JumpToAnywhere(0,2)<CR>
-xnoremap <silent><Plug>(easymotion-jumptoanywhere)
-    \ <Esc>:<C-u>call EasyMotion#JumpToAnywhere(1,2)<CR>
+call s:motion_map_helper({
+    \ 'jumptoanywhere'  : {'fnc' : 'JumpToAnywhere', 'direction': 2},
+    \ })
+"}}}
+
+" -- Next, Previous Motion {{{
+call s:motion_map_helper({
+    \ 'next'            : {'fnc' : 'NextPrevious', 'direction': 0},
+    \ 'previous'        : {'fnc' : 'NextPrevious', 'direction': 1},
+    \ })
+"}}}
+
+" -- Line Motion {{{
+call s:motion_map_helper({
+    \ 'wl'              : {'fnc' : 'WBL', 'direction': 0},
+    \ 'bl'              : {'fnc' : 'WBL', 'direction': 1},
+    \ 'bd-wl'           : {'fnc' : 'WBL', 'direction': 2},
+    \ 'el'              : {'fnc' : 'EL' , 'direction': 0},
+    \ 'gel'             : {'fnc' : 'EL' , 'direction': 1},
+    \ 'bd-el'           : {'fnc' : 'EL' , 'direction': 2},
+    \ 'lineforward'     : {'fnc' : 'WBL', 'direction': 0},
+    \ 'linebackward'    : {'fnc' : 'WBL', 'direction': 1},
+    \ 'lineanywhere'    : {'fnc' : 'WBL', 'direction': 2},
+    \ })
 "}}}
 
 " -- Repeat Motion {{{
@@ -235,59 +215,8 @@ noremap  <silent><Plug>(easymotion-dotrepeat)
     \      :<C-u>call EasyMotion#DotRepeat()<CR>
 "}}}
 
-" -- Next,Previous Motion {{{
-noremap  <silent><Plug>(easymotion-next)
-    \      :<C-u>call EasyMotion#NextPrevious(0,0)<CR>
-xnoremap <silent><Plug>(easymotion-next)
-    \      :<C-u>call EasyMotion#NextPrevious(1,0)<CR>
-
-noremap  <silent><Plug>(easymotion-prev)
-    \      :<C-u>call EasyMotion#NextPrevious(0,1)<CR>
-xnoremap <silent><Plug>(easymotion-prev)
-    \      :<C-u>call EasyMotion#NextPrevious(1,1)<CR>
-"}}}
-
-" -- Line Motion {{{
-" Word Line: {{{
-noremap  <silent><Plug>(easymotion-wl)         :<C-u>call EasyMotion#WBL(0,0)<CR>
-xnoremap <silent><Plug>(easymotion-wl)    <Esc>:<C-u>call EasyMotion#WBL(1,0)<CR>
-noremap  <silent><Plug>(easymotion-bl)         :<C-u>call EasyMotion#WBL(0,1)<CR>
-xnoremap <silent><Plug>(easymotion-bl)    <Esc>:<C-u>call EasyMotion#WBL(1,1)<CR>
-noremap  <silent><Plug>(easymotion-bd-wl)      :<C-u>call EasyMotion#WBL(0,2)<CR>
-xnoremap <silent><Plug>(easymotion-bd-wl) <Esc>:<C-u>call EasyMotion#WBL(1,2)<CR>
-"}}}
-
-" End Word Line: {{{
-noremap  <silent><Plug>(easymotion-el)         :<C-u>call EasyMotion#EL(0,0)<CR>
-xnoremap <silent><Plug>(easymotion-el)    <Esc>:<C-u>call EasyMotion#EL(1,0)<CR>
-noremap  <silent><Plug>(easymotion-gel)        :<C-u>call EasyMotion#EL(0,1)<CR>
-xnoremap <silent><Plug>(easymotion-gel)   <Esc>:<C-u>call EasyMotion#EL(1,1)<CR>
-noremap  <silent><Plug>(easymotion-bd-el)      :<C-u>call EasyMotion#EL(0,2)<CR>
-xnoremap <silent><Plug>(easymotion-bd-el) <Esc>:<C-u>call EasyMotion#EL(1,2)<CR>
-"}}}
-
-" LineAnywhere Line: {{{
-noremap  <silent><Plug>(easymotion-lineforward)
-    \      :<C-u>call EasyMotion#LineAnywhere(0,0)<CR>
-xnoremap <silent><Plug>(easymotion-lineforward)
-    \ <Esc>:<C-u>call EasyMotion#LineAnywhere(1,0)<CR>
-
-noremap  <silent><Plug>(easymotion-linebackward)
-    \      :<C-u>call EasyMotion#LineAnywhere(0,1)<CR>
-xnoremap <silent><Plug>(easymotion-linebackward)
-    \ <Esc>:<C-u>call EasyMotion#LineAnywhere(1,1)<CR>
-
-noremap  <silent><Plug>(easymotion-lineanywhere)
-    \      :<C-u>call EasyMotion#LineAnywhere(0,2)<CR>
-xnoremap <silent><Plug>(easymotion-lineanywhere)
-    \ <Esc>:<C-u>call EasyMotion#LineAnywhere(1,2)<CR>
-
-"}}}
-"}}}
-
 noremap  <silent><Plug>(easymotion-activate) :<C-u>call EasyMotion#activate(0)<CR>
 xnoremap <silent><Plug>(easymotion-activate) :<C-u>call EasyMotion#activate(1)<CR>
-
 " }}}
 
 " == Default key mapping {{{


### PR DESCRIPTION
The find_motion_map_helper function makes it very easy to generate mappings - and there's actually no reason that it needs to be restricted to "find" mappings. This changes makes the helper function more flexible and uses it to generate almost all of the mappings. As a result, there is much less code duplication in the mapping generation. It is also much easier to make universal changes to how all the mappings work. (That will make it much easier to solve a problem I've been having involving inclusive/exclusive movement.)